### PR TITLE
Temporary noindex

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Temporary noindex to prevent dev pages from showing up on Google while validating sitemaps -->
+    <!-- TODO: Remove when ready to index -->
+    <meta name="robots" content="noindex" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Datastore Search</title>


### PR DESCRIPTION
To prevent Google from indexing our dev pages while validating possible sitemaps