### PR TITLE
Fix filters bug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "[vue]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/cypress/integration/advanced.spec.js
+++ b/cypress/integration/advanced.spec.js
@@ -367,7 +367,7 @@ describe('The advanced search', { testIsolation: false }, () => {
             });
         });
 
-        it.only('can export and import filters', () => {
+        it('can export and import filters', () => {
             cy.get('[data-cy="add-rule"]').click();
             cy.contains('Select field').click();
             cy.wait(1000);

--- a/cypress/integration/advanced.spec.js
+++ b/cypress/integration/advanced.spec.js
@@ -428,6 +428,49 @@ describe('The advanced search', { testIsolation: false }, () => {
             });
         });
 
+        it('restores exported and imported filters correctly', () => {
+            // Add some filters
+            cy.get('[data-cy="group-or"]').click();
+
+            cy.get('[data-cy="add-rule"]').click();
+            cy.contains('Select field').click();
+            cy.get('[data-cy="field-selector"]').contains('Sector Code');
+            cy.get('[data-cy="field-selector"]').type('Sector Code{enter}');
+            cy.get('[data-cy="filter-combo-input"]').type('11110');
+
+            cy.get('[data-cy="add-rule"]').click();
+            cy.contains('Select field').click();
+            cy.get('[data-cy="field-selector"]').last().contains('Sector Code');
+            cy.get('[data-cy="field-selector"]').last().type('Sector Code{enter}');
+            cy.get('[data-cy="filter-combo-input"]').last().type('11120');
+
+            // Export
+            const downloadsFolder = Cypress.config('downloadsFolder');
+            cy.get('[data-cy="open-export-modal"]').click();
+            cy.get('[data-cy="export-filters"]').click();
+
+            // Reset
+            cy.get('[data-cy="reset-filters"]').click();
+            cy.get('[data-cy="reset-filters"]').contains('Confirm').click();
+
+            //Import
+            cy.get('[data-cy="build-query"]').click();
+            cy.get('[data-cy="open-import-modal"]').click();
+            cy.task('isExistFile', downloadsFolder).then((filename) => {
+                cy.readFile(filename).then((fileContent) => {
+                    cy.get('input[type="file"]').attachFile({
+                        fileContent: fileContent,
+                        fileName: filename,
+                        mimeType: 'application/json',
+                    });
+                    cy.get('[data-cy="import-filters"]').click();
+                });
+            });
+
+            // Assert that filters are correct
+            cy.get('[data-cy="group-or"]').should('have.class', 'bg-blue-300');
+        });
+
         it('restores filters after page refresh', () => {
             // Add some filters
             cy.get('[data-cy="group-or"]').click();

--- a/cypress/integration/advanced.spec.js
+++ b/cypress/integration/advanced.spec.js
@@ -427,5 +427,31 @@ describe('The advanced search', { testIsolation: false }, () => {
                 });
             });
         });
+
+        it('restores filters after page refresh', () => {
+            // Add some filters
+            cy.get('[data-cy="group-or"]').click();
+
+            cy.get('[data-cy="add-rule"]').click();
+            cy.contains('Select field').click();
+            cy.get('[data-cy="field-selector"]').contains('Sector Code');
+            cy.get('[data-cy="field-selector"]').type('Sector Code{enter}');
+            cy.get('[data-cy="filter-combo-input"]').type('11110');
+
+            cy.get('[data-cy="add-rule"]').click();
+            cy.contains('Select field').click();
+            cy.get('[data-cy="field-selector"]').last().contains('Sector Code');
+            cy.get('[data-cy="field-selector"]').last().type('Sector Code{enter}');
+            cy.get('[data-cy="filter-combo-input"]').last().type('11120');
+
+            // Run the filter
+            cy.get('[data-cy="run-filters"]').click();
+
+            // Refresh the page
+            cy.reload();
+
+            // Assert that the filters are correct
+            cy.get('[data-cy="group-or"]').should('have.class', 'bg-blue-300');
+        });
     });
 });

--- a/cypress/integration/advanced.spec.js
+++ b/cypress/integration/advanced.spec.js
@@ -502,5 +502,27 @@ describe('The advanced search', { testIsolation: false }, () => {
             // Assert that the filters are correct
             cy.get('[data-cy="group-or"]').should('have.class', 'bg-blue-300');
         });
+
+        it('persists filters correctly after export', () => {
+            // Set first group to OR
+            cy.get('[data-cy="group-or"]').click();
+
+            // Add second nested group with OR
+            cy.get('[data-cy="add-group"]').click();
+            cy.get('[data-cy="group-or"]').last().click();
+
+            // Add third nested group with OR
+            cy.get('[data-cy="add-group"]').last().click();
+            cy.get('[data-cy="group-or"]').last().click();
+
+            // Click export
+            cy.get('[data-cy="open-export-modal"]').click();
+            cy.get('[data-cy="export-filters"]').should('be.visible');
+
+            // Assert that all three ORs are still set
+            cy.get('[data-cy="group-or"]').eq(0).should('have.class', 'bg-blue-300');
+            cy.get('[data-cy="group-or"]').eq(1).should('have.class', 'bg-blue-300');
+            cy.get('[data-cy="group-or"]').eq(2).should('have.class', 'bg-blue-300');
+        });
     });
 });

--- a/cypress/integration/advanced.spec.js
+++ b/cypress/integration/advanced.spec.js
@@ -51,6 +51,12 @@ describe('The advanced search', { testIsolation: false }, () => {
         });
 
         it('captures a representation of the basic search input', () => {
+            cy.fixture('simple_q_test').then((simple_q_test) => {
+                cy.intercept(
+                    `https://dev-api.iatistandard.org/dss/activity/search*`,
+                    simple_q_test,
+                );
+            });
             const query = 'test';
             cy.visit(`/?q=${query}`);
             const validate = (value) => {
@@ -338,7 +344,7 @@ describe('The advanced search', { testIsolation: false }, () => {
             cy.fixture('advanced_q_test').then((advanced_q_test) => {
                 cy.intercept(
                     buildRouteMatcher({ q: '(location_point_latlon:[-31.7,-45.0 TO 31.7,45.0])' }),
-                    advanced_q_test
+                    advanced_q_test,
                 ).as('spatialQuery');
                 cy.get('[data-cy="run-filters"]').click({ force: true });
                 cy.wait('@spatialQuery').then((interception) => {

--- a/cypress/integration/results.spec.js
+++ b/cypress/integration/results.spec.js
@@ -7,6 +7,9 @@ describe('The results view', () => {
         cy.get('[data-cy="search-input"]').should('be.visible');
     });
     it('has a visible button for showing the advanced search sidebar', () => {
+        cy.fixture('simple_q_test').then((simple_q_test) => {
+            cy.intercept(`https://dev-api.iatistandard.org/dss/activity/search*`, simple_q_test);
+        });
         const query = 'test';
         cy.visit(`/?q=${query}`);
         cy.get('[data-cy="advanced-search-results"]').should('be.visible');

--- a/src/components/FilterGroup.vue
+++ b/src/components/FilterGroup.vue
@@ -41,6 +41,7 @@ const onDeleteItem = (group, itemId) => {
     <div class="p-2 border border-iati-grey">
         <FilterGroupActions
             :deletable="deletable"
+            :group="group"
             @add-rule="emit('addRule', group)"
             @add-group="emit('addGroup', group)"
             @toggle-operator="(operator) => emit('toggleOperator', group, operator)"

--- a/src/components/FilterGroup.vue
+++ b/src/components/FilterGroup.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { v4 as uuidv4 } from 'uuid';
 import FilterGroupActions from './FilterGroupActions.vue';
 import FilterGroupItem from './FilterGroupItem.vue';
 
@@ -8,33 +7,6 @@ defineProps({
     deletable: { type: Boolean, default: true },
 });
 const emit = defineEmits(['addRule', 'addGroup', 'toggleOperator', 'delete']);
-
-const onAddRule = (group) => {
-    const items = group.items.concat({
-        id: uuidv4(),
-        type: null,
-        field: null,
-        value: null,
-        operator: 'equals',
-        joinOperator: 'AND',
-    });
-    group.items = items;
-};
-const onAddGroup = (group) => {
-    const items = group.items.concat({
-        id: uuidv4(),
-        type: 'group',
-        operator: 'AND',
-        items: [],
-    });
-    group.items = items;
-};
-const onToggleOperator = (group, operator) => {
-    group.operator = operator;
-};
-const onDeleteItem = (group, itemId) => {
-    group.items = group.items.filter((item) => item.id !== itemId);
-};
 </script>
 
 <template>
@@ -42,26 +14,24 @@ const onDeleteItem = (group, itemId) => {
         <FilterGroupActions
             :deletable="deletable"
             :group="group"
-            @add-rule="emit('addRule', group)"
-            @add-group="emit('addGroup', group)"
-            @toggle-operator="(operator) => emit('toggleOperator', group, operator)"
-            @delete="emit('delete', group)"
+            @add-rule="(groupId) => emit('addRule', groupId)"
+            @add-group="(groupId) => emit('addGroup', groupId)"
+            @toggle-operator="(groupId, operator) => emit('toggleOperator', groupId, operator)"
+            @delete="(groupId) => emit('delete', groupId)"
         />
         <div v-for="item in group.items" :key="item.id">
             <div v-if="item.type !== 'group'">
-                <FilterGroupItem
-                    :key="item.id"
-                    :filter="item"
-                    @delete="onDeleteItem(group, item.id)"
-                />
+                <FilterGroupItem :key="item.id" :filter="item" @delete="emit('delete', item.id)" />
             </div>
             <div v-else class="mt-3">
                 <FilterGroup
                     :group="item"
-                    @add-rule="onAddRule"
-                    @add-group="onAddGroup"
-                    @toggle-operator="onToggleOperator"
-                    @delete="onDeleteItem(group, item.id)"
+                    @add-rule="(itemId) => emit('addRule', itemId)"
+                    @add-group="(itemId) => emit('addGroup', itemId)"
+                    @toggle-operator="
+                        (itemId, operator) => emit('toggleOperator', itemId, operator)
+                    "
+                    @delete="(itemId) => emit('delete', itemId)"
                 />
             </div>
         </div>

--- a/src/components/FilterGroupActions.vue
+++ b/src/components/FilterGroupActions.vue
@@ -6,10 +6,14 @@ import i18n from '../i18n';
 
 const { t } = i18n.global;
 
-defineProps({ deletable: { type: Boolean, default: true } });
+const props = defineProps({
+    deletable: { type: Boolean, default: true },
+    group: { type: Object, default: () => {} },
+});
+
 const emits = defineEmits(['addRule', 'addGroup', 'toggleOperator', 'delete']);
 
-const operator = ref('AND');
+const operator = ref(props.group.operator);
 const toggleOperator = () => {
     operator.value = operator.value === t('message.and') ? t('message.or') : t('message.and');
     emits('toggleOperator', operator.value);

--- a/src/components/FilterGroupActions.vue
+++ b/src/components/FilterGroupActions.vue
@@ -1,22 +1,20 @@
 <script setup>
 import { QuestionMarkCircleIcon, XCircleIcon } from '@heroicons/vue/20/solid';
-import { ref } from 'vue';
 import AppButton from '../components/AppButton.vue';
 import i18n from '../i18n';
 
+// eslint-disable-next-line no-unused-vars
 const { t } = i18n.global;
 
-const props = defineProps({
+defineProps({
     deletable: { type: Boolean, default: true },
     group: { type: Object, default: () => {} },
 });
 
 const emits = defineEmits(['addRule', 'addGroup', 'toggleOperator', 'delete']);
 
-const operator = ref(props.group.operator);
-const toggleOperator = () => {
-    operator.value = operator.value === t('message.and') ? t('message.or') : t('message.and');
-    emits('toggleOperator', operator.value);
+const toggleOperator = (operator) => {
+    emits('toggleOperator', operator);
 };
 const buttonClasses =
     'h-8 text-xs px-2 py-1 text-gray-700 font-medium text-xs leading-tight uppercase hover:bg-blue-500 focus:outline-none focus:ring-0 active:bg-blue-800 transition duration-150 ease-in-out';
@@ -27,20 +25,20 @@ const buttonClasses =
         <div class="py-1">
             <span class="mr-3 text-sm">{{ $t('message.group_operator') }}</span>
             <button
-                :class="[operator === $t('message.and') ? 'bg-blue-300' : '', buttonClasses]"
+                :class="[group.operator === 'AND' ? 'bg-blue-300' : '', buttonClasses]"
                 class="border-l border-t border-b rounded-l"
                 type="button"
                 data-cy="group-and"
-                @click="toggleOperator"
+                @click="toggleOperator('AND')"
             >
                 {{ $t('message.and') }}
             </button>
             <button
-                :class="[operator === $t('message.or') ? 'bg-blue-300' : '', buttonClasses]"
+                :class="[group.operator === 'OR' ? 'bg-blue-300' : '', buttonClasses]"
                 type="button"
                 class="border-r border-t border-b rounded-r"
                 data-cy="group-or"
-                @click="toggleOperator"
+                @click="toggleOperator('OR')"
             >
                 {{ $t('message.or') }}
             </button>

--- a/src/components/FilterGroupActions.vue
+++ b/src/components/FilterGroupActions.vue
@@ -6,16 +6,13 @@ import i18n from '../i18n';
 // eslint-disable-next-line no-unused-vars
 const { t } = i18n.global;
 
-defineProps({
+const props = defineProps({
     deletable: { type: Boolean, default: true },
     group: { type: Object, default: () => {} },
 });
 
 const emits = defineEmits(['addRule', 'addGroup', 'toggleOperator', 'delete']);
 
-const toggleOperator = (operator) => {
-    emits('toggleOperator', operator);
-};
 const buttonClasses =
     'h-8 text-xs px-2 py-1 text-gray-700 font-medium text-xs leading-tight uppercase hover:bg-blue-500 focus:outline-none focus:ring-0 active:bg-blue-800 transition duration-150 ease-in-out';
 </script>
@@ -29,7 +26,7 @@ const buttonClasses =
                 class="border-l border-t border-b rounded-l"
                 type="button"
                 data-cy="group-and"
-                @click="toggleOperator('AND')"
+                @click="emits('toggleOperator', props.group.id, 'AND')"
             >
                 {{ $t('message.and') }}
             </button>
@@ -38,7 +35,7 @@ const buttonClasses =
                 type="button"
                 class="border-r border-t border-b rounded-r"
                 data-cy="group-or"
-                @click="toggleOperator('OR')"
+                @click="emits('toggleOperator', props.group.id, 'OR')"
             >
                 {{ $t('message.or') }}
             </button>
@@ -54,7 +51,7 @@ const buttonClasses =
         </button>
 
         <div v-if="deletable" class="p-2 float-right">
-            <span data-cy="remove-group" @click="emits('delete')">
+            <span data-cy="remove-group" @click="emits('delete', props.group.id)">
                 <XCircleIcon class="h-6 cursor-pointer" />
             </span>
         </div>
@@ -65,7 +62,7 @@ const buttonClasses =
             size="sm"
             class="mr-2 px-[8px]"
             data-cy="add-rule"
-            @click="emits('addRule')"
+            @click="emits('addRule', props.group.id)"
         >
             <span class="uppercase">{{ $t('message.add_rule') }}</span>
         </AppButton>
@@ -74,7 +71,7 @@ const buttonClasses =
             class="px-[8px]"
             size="sm"
             data-cy="add-group"
-            @click="emits('addGroup')"
+            @click="emits('addGroup', props.group.id)"
         >
             <span class="uppercase">{{ $t('message.add_group') }}</span>
         </AppButton>

--- a/src/components/FilterInputs.vue
+++ b/src/components/FilterInputs.vue
@@ -36,33 +36,68 @@ const getFiltersFromGroup = (group, parentGroupOperator) => {
             item.joinOperator = group.operator;
             return filters.concat(item);
         }, []),
-        getBracketFilter('closing', group.operator)
+        getBracketFilter('closing', group.operator),
     );
 };
 
-const onAddRule = (group, rule = {}) => {
-    const items = group.items.concat({
-        id: uuidv4(),
-        type: null,
-        field: null,
-        value: null,
-        operator: 'equals',
-        joinOperator: 'AND',
-        ...rule,
-    });
-    group.items = items;
+const onAddRule = (group, groupId, rule = {}) => {
+    if (group.id == groupId) {
+        const items = group.items.concat({
+            id: uuidv4(),
+            type: null,
+            field: null,
+            value: null,
+            operator: 'equals',
+            joinOperator: 'AND',
+            ...rule,
+        });
+        group.items = items;
+    } else {
+        group.items.forEach((item) => {
+            if (item.type === 'group') {
+                onAddRule(item, groupId);
+            }
+        });
+    }
 };
-const onAddGroup = () => {
-    const items = group.items.concat({
-        id: uuidv4(),
-        type: 'group',
-        operator: 'AND',
-        items: [],
-    });
-    group.items = items;
+const onAddGroup = (group, groupId) => {
+    if (group.id == groupId) {
+        const items = group.items.concat({
+            id: uuidv4(),
+            type: 'group',
+            operator: 'AND',
+            items: [],
+        });
+        group.items = items;
+    } else {
+        group.items.forEach((item) => {
+            if (item.type === 'group') {
+                onAddGroup(item, groupId);
+            }
+        });
+    }
 };
-const onToggleOperator = (group, operator) => {
-    group.operator = operator;
+const onToggleOperator = (group, groupId, operator) => {
+    if (group.id == groupId) {
+        group.operator = operator;
+    } else {
+        group.items.forEach((item) => {
+            if (item.type === 'group') {
+                onToggleOperator(item, groupId, operator);
+            }
+        });
+    }
+};
+const onDeleteItem = (group, itemId) => {
+    if (group.items.map((item) => item.id).includes(itemId)) {
+        group.items = group.items.filter((item) => item.id !== itemId);
+    } else {
+        group.items.forEach((item) => {
+            if (item.type === 'group') {
+                onDeleteItem(item, itemId);
+            }
+        });
+    }
 };
 const validateGroup = (grup) => {
     let isValid = true;
@@ -105,7 +140,6 @@ const populateGroupFromFilters = (filters, group, startIndex = 0) => {
     let nextIndex = startIndex;
     // reset group, but preserve reactivity if available
     group.id = uuidv4();
-    group.operator = 'AND';
     group.items = [];
 
     // populate group from filters
@@ -113,11 +147,16 @@ const populateGroupFromFilters = (filters, group, startIndex = 0) => {
         if (index === nextIndex) {
             if (item.type === 'grouping') {
                 if (item.value === '(' && index) {
-                    const nestedGroup = { id: uuidv4(), type: 'group', operator: 'AND', items: [] };
+                    const nestedGroup = {
+                        id: uuidv4(),
+                        type: 'group',
+                        operator: item.joinOperator,
+                        items: [],
+                    };
                     const { index: nestedIndex } = populateGroupFromFilters(
                         filters,
                         nestedGroup,
-                        index + 1
+                        index + 1,
                     );
                     group.items.push(nestedGroup);
                     nextIndex = nestedIndex + 1;
@@ -128,7 +167,7 @@ const populateGroupFromFilters = (filters, group, startIndex = 0) => {
                 }
             } else {
                 group.operator = item.joinOperator;
-                onAddRule(group, item);
+                onAddRule(group, group.id, item);
                 nextIndex = index + 1;
             }
         }
@@ -141,7 +180,7 @@ watch(
     () => props.filters,
     () => {
         populateGroupFromFilters(props.filters, group);
-    }
+    },
 );
 onBeforeMount(() => {
     if (props.filters && props.filters.length) {
@@ -156,9 +195,10 @@ onBeforeMount(() => {
             v-if="filters.length"
             :group="group"
             :deletable="false"
-            @add-rule="onAddRule"
-            @add-group="onAddGroup"
-            @toggle-operator="onToggleOperator"
+            @add-rule="(groupId) => onAddRule(group, groupId)"
+            @add-group="(groupId) => onAddGroup(group, groupId)"
+            @toggle-operator="(groupId, operator) => onToggleOperator(group, groupId, operator)"
+            @delete="(itemId) => onDeleteItem(group, itemId)"
         />
     </div>
 


### PR DESCRIPTION
Relates to https://github.com/IATI/datastore-search/issues/612

Move all filter state to being controlled in a single place, instead of child components trying to mutate parent state, which wasn't being persisted correctly on export/refresh etc.