### PR TITLE
Fix rebuilding groups from filters

### DIFF
--- a/cypress/integration/advanced.spec.js
+++ b/cypress/integration/advanced.spec.js
@@ -524,5 +524,27 @@ describe('The advanced search', { testIsolation: false }, () => {
             cy.get('[data-cy="group-or"]').eq(1).should('have.class', 'bg-blue-300');
             cy.get('[data-cy="group-or"]').eq(2).should('have.class', 'bg-blue-300');
         });
+
+        it('persists filters correctly after export (2)', () => {
+            // Set first group to OR
+            cy.get('[data-cy="group-and"]').click();
+
+            // Add second nested group with OR
+            cy.get('[data-cy="add-group"]').click();
+            cy.get('[data-cy="group-or"]').last().click();
+
+            // Add third nested group with OR
+            cy.get('[data-cy="add-group"]').last().click();
+            cy.get('[data-cy="group-and"]').last().click();
+
+            // Click export
+            cy.get('[data-cy="open-export-modal"]').click();
+            cy.get('[data-cy="export-filters"]').should('be.visible');
+
+            // Assert that all three ORs are still set
+            cy.get('[data-cy="group-and"]').eq(0).should('have.class', 'bg-blue-300');
+            cy.get('[data-cy="group-or"]').eq(1).should('have.class', 'bg-blue-300');
+            cy.get('[data-cy="group-and"]').eq(2).should('have.class', 'bg-blue-300');
+        });
     });
 });

--- a/src/components/FilterInputs.vue
+++ b/src/components/FilterInputs.vue
@@ -161,6 +161,7 @@ const populateGroupFromFilters = (filters, group, startIndex = 0) => {
                     group.items.push(nestedGroup);
                     nextIndex = nestedIndex + 1;
                 } else if (item.value === ')') {
+                    group.operator = item.joinOperator
                     nextIndex = index;
                 } else {
                     nextIndex++;


### PR DESCRIPTION
Correctly applies nested operators to the UI when importing filters