### PR TITLE
Fixes from linting PR

### DIFF
--- a/locale/en/index.js
+++ b/locale/en/index.js
@@ -115,12 +115,12 @@ export default {
         download_results_file: 'Download Results File',
         download_confirmation_1: 'Download',
         download_confirmation_2a: 'this IATI Activity',
-        download_confirmation_2b: '%{count} results',
+        download_confirmation_2b: '{count} results',
         download_confirmation_3: 'from the',
         download_confirmation_4a: 'Activity',
         download_confirmation_4b: 'Transaction',
         download_confirmation_4c: 'Budget',
-        download_confirmation_5a: 'core in %{format} format?',
+        download_confirmation_5a: 'core in {format} format?',
         download_confirmation_5b: `
             core in Excel-optimised* CSV format?<br /><br /><span
                 class="text-sm"
@@ -189,9 +189,9 @@ export default {
         select_field: 'Select field',
         true: 'TRUE',
         false: 'FALSE',
-        select_from_codes: 'Select from %{name} codes',
+        select_from_codes: 'Select from {name} codes',
         found_matching_iati_activities:
-            'Found <b>%{count}</b> matching IATI activities',
+            'Found <b>{count}</b> matching IATI activities',
         sort: 'Sort',
         no_match: 'No matching IATI Activities - please try a different search',
         not_found: 'Not Found',
@@ -200,7 +200,7 @@ export default {
             <a class="hover:underline" href="/">Home</a>
         `,
         advanced: 'Advanced',
-        found_activities: 'Found <b>%{count}</b> activities',
+        found_activities: 'Found <b>{count}</b> activities',
         results_by_advanced_search:
             'Results filtered by advanced parameters. See <b>Advanced Search</b> tab for more details.',
         relevance: 'Relevance',
@@ -224,7 +224,7 @@ export default {
         selection_is_required: 'Selection is required',
         value_is_required: 'Value is required',
         date_is_required: 'Date is required',
-        is_not_allowed: '%{bad} is not allowed for Datastore Search queries',
+        is_not_allowed: '{bad} is not allowed for Datastore Search queries',
         percentage_validation: 'Percentage must be between 0 and 100',
         integer_validation: 'Value must be a whole number',
         fetch_error:

--- a/locale/fr/index.js
+++ b/locale/fr/index.js
@@ -38,12 +38,12 @@ export default {
         download_results_file: 'Télécharger le fichier de résultats',
         download_confirmation_1: 'Télécharger',
         download_confirmation_2a: 'cette activité de l’IITA',
-        download_confirmation_2b: '%{count} résultats',
+        download_confirmation_2b: '{count} résultats',
         download_confirmation_3: 'depuis cette',
         download_confirmation_4a: 'Activité',
         download_confirmation_4b: 'Transaction',
         download_confirmation_4c: 'Budget',
-        download_confirmation_5a: 'éléments de base au format %{format} ?',
+        download_confirmation_5a: 'éléments de base au format {format} ?',
         download_confirmation_5b:
             '\n            éléments de base au format CSV optimisé pour Excel* ?<br /><br /><span\n                class="text-sm"\n                >* L’ouverture du fichier Excel s’effectuera avec un encodage et un formatage corrects, mais les cellules de plus de 32 700 caractères seront tronquées.</span>\n',
         download_confirmation_5c:
@@ -93,9 +93,9 @@ export default {
         select_field: 'Sélectionner un champ',
         true: 'TRUE',
         false: 'FALSE',
-        select_from_codes: 'Sélectionner parmi les codes %{name}',
+        select_from_codes: 'Sélectionner parmi les codes {name}',
         found_matching_iati_activities:
-            '<b>%{count}</b> activités de l’IITA correspondantes ont été trouvées.',
+            '<b>{count}</b> activités de l’IITA correspondantes ont été trouvées.',
         sort: 'Trier',
         no_match:
             'Aucune activité de l’IITA correspondante n’a été trouvée. Veuillez effectuer une nouvelle recherche.',
@@ -103,7 +103,7 @@ export default {
         not_found_para:
             '\n            Malheureusement, nous n’avons pas pu trouver cette page. Veuillez retourner à la page d’<a class="hover:underline" href="/">Accueil</a>',
         advanced: 'Avancé',
-        found_activities: '<b>%{count}</b> activités ont été trouvées.',
+        found_activities: '<b>{count}</b> activités ont été trouvées.',
         relevance: 'Pertinence',
         sort_relevance_label: 'Trier par pertinence',
         identifier: 'Identifiant',
@@ -124,7 +124,7 @@ export default {
         value_is_required: 'La valeur est obligatoire.',
         date_is_required: 'La date est obligatoire.',
         is_not_allowed:
-            '%{bad} n’est pas autorisé pour les requêtes de recherche dans la banque de données.',
+            '{bad} n’est pas autorisé pour les requêtes de recherche dans la banque de données.',
         percentage_validation:
             'Le pourcentage doit être compris entre 0 et 100.',
         integer_validation: 'La valeur doit être un nombre entier.',

--- a/src/components/DownloadButtons.vue
+++ b/src/components/DownloadButtons.vue
@@ -126,9 +126,11 @@ const core = ref('activity');
                                     {{ $t('message.download_confirmation_4c') }}
                                 </option>
                             </select>
-                            <span>
-                                {{ $t('message.download_confirmation_5b') }}
-                            </span>
+                            <!-- eslint-disable vue/no-v-html -->
+                            <span
+                                v-html="$t('message.download_confirmation_5b')"
+                            ></span>
+                            <!-- eslint-enable vue/no-v-html -->
                         </p>
 
                         <p

--- a/src/components/FilterSelectInput.vue
+++ b/src/components/FilterSelectInput.vue
@@ -41,17 +41,18 @@ const global = inject('global');
                 :value="filter.value"
                 @change="(event) => emits('changeValue', event)"
             >
+                <!-- eslint-disable vue/no-v-html -->
                 <option
                     disabled
                     value=""
                     :selected="global.dropdownStateBlank(filter.id)"
-                >
-                    {{
+                    v-html="
                         $t('message.select_from_codes', {
                             name: filter.selectedOption.codelistMeta.name,
                         })
-                    }}
-                </option>
+                    "
+                ></option>
+                <!-- eslint-enable vue/no-v-html -->
                 <option
                     v-for="(valueOption, index) in filter.selectedOption
                         .options"

--- a/src/views/AboutPage.vue
+++ b/src/views/AboutPage.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-v-html -->
 <template>
     <div class="flex flex-col h-full min-w-fit sm:min-w-0">
         <div class="text-left">
@@ -5,21 +6,16 @@
                 <h1 class="text-2xl border-b pb-2 mt-10">
                     {{ $t('message.about_iati_datastore_search') }}
                 </h1>
-                <p class="mt-5">
-                    {{ $t('message.about_para_1') }}
-                </p>
-                <p class="mt-5 ml-10">
-                    {{ $t('message.about_para_2') }}
-                </p>
-                <p class="mt-5 ml-10">
-                    {{ $t('message.about_para_3') }}
-                </p>
-                <p class="mt-5">
-                    {{ $t('message.about_para_4') }}
-                </p>
-                <p class="mt-5 border-b pb-4">
-                    {{ $t('message.about_para_5') }}
-                </p>
+                <!-- eslint-disable vue/no-v-html -->
+                <p class="mt-5" v-html="$t('message.about_para_1')"></p>
+                <p class="mt-5 ml-10" v-html="$t('message.about_para_2')"></p>
+                <p class="mt-5 ml-10" v-html="$t('message.about_para_3')"></p>
+                <p class="mt-5" v-html="$t('message.about_para_4')"></p>
+                <p
+                    class="mt-5 border-b pb-4"
+                    v-html="$t('message.about_para_5')"
+                ></p>
+                <!-- eslint-enable vue/no-v-html -->
             </div>
         </div>
     </div>

--- a/src/views/AdvancedView.vue
+++ b/src/views/AdvancedView.vue
@@ -26,9 +26,12 @@ onUnmounted(() => {
             <p class="text-orange-600 text-left">
                 {{ $t('message.advanced_unavailable_para1') }}
             </p>
-            <p class="pt-6 text-left">
-                {{ $t('message.advanced_unavailable_para2') }}
-            </p>
+            <!-- eslint-disable vue/no-v-html -->
+            <p
+                class="pt-6 text-left"
+                v-html="$t('message.advanced_unavailable_para2')"
+            ></p>
+            <!-- eslint-enable vue/no-v-html -->
         </div>
         <div class="h-full split invisible advanced:visible">
             <div id="split-0"><SideBar /></div>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,8 +1,7 @@
 <template>
     <h1 class="text-3xl pt-5">{{ $t('message.not_found') }}</h1>
-    <p class="text-lg p-4">
-        {{ $t('message.not_found_para') }}
-    </p>
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <p class="text-lg p-4" v-html="$t('message.not_found_para')"></p>
 </template>
 
 <script>


### PR DESCRIPTION
Two fixes from previous linting PR:
- For i18n messages containing html, the `v-html` binding must be used. Eslint throws a warning here, but the [docs](https://eslint.vuejs.org/rules/no-v-html.html#when-not-to-use-it) say it is okay to ignore if the html is sanitised. In this case it is static so should be fine.
- A recent dependabot PR to develop upgraded the `vue-i18n` package from major version 9 to 10, so the format for interpolating variables into messages has changed from `%{...}` to `{...}`